### PR TITLE
Add support for indenting after brackets

### DIFF
--- a/languages/d/indents.scm
+++ b/languages/d/indents.scm
@@ -1,0 +1,3 @@
+(_ "{" "}" @end) @indent
+(_ "[" "]" @end) @indent
+(_ "(" ")" @end) @indent


### PR DESCRIPTION
Zed was not indenting to the correct level when you hit return after opening brackets like it does in other languages so I've added support to this extension to do just that. I copied the functionality from the Zed C# extension.