### PR TITLE
Bump to 0.9.1 of the tree-sitter-d grammar

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_d"
-version = "0.0.9"
+version = "0.0.10"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "d"
 name = "D"
 description = "D language support"
-version = "0.0.9"
+version = "0.0.10"
 schema_version = 1
 authors = ["Garrett D'Amore <garrett@staysail.tech>"]
 repository = "https://github.com/staysail/zed-d"
@@ -12,4 +12,4 @@ language = "D"
 
 [grammars.d]
 repository = "https://github.com/gdamore/tree-sitter-d"
-commit = "45e5f1e9d6de2c68591bc8e5ec662cf18e950b4a"
+commit = "64f27931b4e6fdd75af1102c79bacbca68a8dacc"


### PR DESCRIPTION
Updates the `d` grammar from v0.8.2 to v0.9.1 (`64f27931`) and bumps the extension version to 0.0.10 in both `extension.toml` and `Cargo.toml`. Note there is no v0.9.0 tag upstream — the grammar repo jumps from v0.8.3 to v0.9.1. The Zed textobjects query is intentionally unchanged: the v0.9.x grammar renamed nvim capture names (`.inside`/`.around` → `.inner`/`.outer`), but Zed uses the `.inside`/`.around` convention the query already has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)